### PR TITLE
fix markup and bibliographic references in section 3.1

### DIFF
--- a/src/bib/number-theory.bib
+++ b/src/bib/number-theory.bib
@@ -1,11 +1,10 @@
-
-@book{hardy_introduction_1979,
-	series = {Oxford science publications},
-	title = {An {Introduction} to the {Theory} of {Numbers}},
-	isbn = {978-0-19-853171-5},
-	url = {https://books.google.co.uk/books?id=FlUj0Rk_rF4C},
-	publisher = {Clarendon Press},
-	author = {Hardy, G.H. and Godfrey Harold Hardy, E.M.W. and Wright, E.M. and Wright, E.W.},
-	year = {1979},
-	lccn = {99461762}
+@book{hardyIntroductionTheoryNumbers1979,
+  title = {An {{Introduction}} to the {{Theory}} of {{Numbers}}},
+  author = {Hardy, G.H. and Godfrey Harold Hardy, E.M.W. and Wright, E.M. and Wright, E.W.},
+  date = {1979},
+  series = {Oxford Science Publications},
+  publisher = {{Clarendon Press}},
+  url = {https://books.google.co.uk/books?id=FlUj0Rk_rF4C},
+  isbn = {978-0-19-853171-5},
+  lccn = {99461762}
 }

--- a/src/chapters/03_existence_proof.tex
+++ b/src/chapters/03_existence_proof.tex
@@ -2,7 +2,7 @@
 
 \section{Introduction}
 
-The theorem which will ultimately be established in section 4 relies upon a fundamental theorem in number theory – in fact *the* fundamental theorem.
+The theorem which will ultimately be established in Chapter 4 relies upon a fundamental theorem in number theory – in fact \emph{the} fundamental theorem.
 The Fundamental Theorem of Arithmetic states that every positive integer, except 1, can be expressed uniquely as a product of primes.
 Proof of this theorem can be found in
 \cite{hardyIntroductionTheoryNumbers1979}.


### PR DESCRIPTION
Update `src/bib/number-theory.bib` with an export from Zotero using Better BibTeX and replace a Markdown emphasis with the equivalent LaTeX.