### PR TITLE
fix broken equation reference

### DIFF
--- a/src/chapters/03_existence_proof.tex
+++ b/src/chapters/03_existence_proof.tex
@@ -57,7 +57,7 @@ Each member of this set must occur exactly once in the pairs of the starter – 
 Because of the cyclical construction the condition is automatically true for successive rows if true
 for the first.
 
-Consider the existence in Table \ref{tab:cyclic-room} of an arbitrary pair $\{a, b\}$.
+Consider the existence in \eqref{eq:cyclic} of an arbitrary pair $\{a, b\}$.
 We know one of the following must be true.
 
 Either $\{2 + i, 5 + i\} = \{a, b\}$ or $\{1 + i, 6 + i\} = \{a, b\}$ or $\{3 + i, 4 + i\} = \{a, b\}$ for $i = 0, 1, 2, \ldots, 6$.


### PR DESCRIPTION
There was a broken reference in the text to a table. Fixed by replacing with correct reference to earlier equation.