### PR TITLE
Fix reference to Example XXX in Section 3.2.2

### DIFF
--- a/src/chapters/03_existence_proof.tex
+++ b/src/chapters/03_existence_proof.tex
@@ -192,7 +192,7 @@ $s_1 + a_1, t_1 + a_1, s_2 + a_2, \ldots, s_{(g - 1)/2} + a_{(g - 1)/2}, t_{(g -
 are precisely all the non-zero elements of $G$.
 
 The \inlinedef{starter-adder} method employed in the above example was introduced\footnote{Both Howell and Whitfield had previously found starters and adders, but the precise method used here due to Stanton and Mullin.}
-by
+by Stanton and Mullin
 \cite{stantonConstructionRoomSquares1968},
 who used it to construct Room squares of side 11.
 They also went on to apply the method to larger squares and gave the first real suggestions that the number of Room squares is infinite.
@@ -251,7 +251,7 @@ On closer inspection the two types of starters are identical\footnote{The starte
 
 Starters of this form are called \inlinedef{patterned} starters.
 
-Stanton and Mullin went on to show that using the method outlined in Example XXX they could find adders corresponding to the patterned starters for $k = 7, 11, 13, 15, 17$.
+Stanton and Mullin went on to they could find adders corresponding to the patterned starters for $k = 7, 11, 13, 15, 17$.
 They had problems with 9 (but were able to construct one using a different method) and finding it too laborious for $k > 19$ they developed an algorithm which, when implemented in Fortran, was able to find patterned starters with adders for all odd $k$ up to 49, with no further gaps.
 Suggesting the possibility (which they conjectured) that there are Room squares for all odd side greater than 5.
 


### PR DESCRIPTION
This corresponds to an original reference to Example 2.1 on page 22 of the original report. But the original report doesn't have an Example 2.1 so the sentence has been rewritten to exclude the reference.