### PR TITLE
Fix Example references

### DIFF
--- a/src/chapters/03_existence_proof.tex
+++ b/src/chapters/03_existence_proof.tex
@@ -418,8 +418,7 @@ Rather than examine this approach we move on to a type of starter which provides
 If $x$ is a primitive element in $G = GF(p^n)$, then the elements $x^1, x^2, \ldots, x^{p^n - 1} = 1$ are, by definition, all of $G \backslash \{0\}$.
 Alternatively, we can write $G \backslash \{0\} = \{x^0 = 1, x^1, \ldots, x^{p^n - 2}\}$.
 
-\begin{example}
-\label{eg:mullin-nemeth}
+\begin{example}[label=eg:mullin-nemeth]
 The field $GF(23)$ has a primitive root $x = 5$, because $5^0 = 1$, $5^1 = 5$, $5^2 = 2$, $5^3 = 10$, $5^4 = 4$, $5^5 = 20$, $5^6 = 8$, $5^7 = 17$, $5^8 = 16$, $5^9 = 11$, $5^{10} = 9$ $5^{11} = 22$, $5^{12} = 18$, $5^{13} = 21$, $5^{14} = 13$, $5^{15} = 19$, $5^{16} = 3$, $5^{17} = 15$, $5^{18} = 6$, $5^{19} = 7$, $5^{20} = 12$, $5^{21} = 14$ are all the non-zero elements of $GF(23)$.
 \end{example}
 
@@ -433,8 +432,7 @@ and
 were already known, was equivalent to proving the existence of Room squares for (nearly) all orders $p^n + 1$.
 Before introducing the general construction for these starters, we illustrate the basic method with a couple of examples of particular cases.
 
-\begin{example}
-\label{ex:strong-starter}
+\begin{example}[label=ex:strong-starter]
 We can create a strong starter from Example \ref{eg:mullin-nemeth} simply by pairing the elements in the order in which they were generated.
 \begin{equation}
 S = \{\{1, 5\}, \{2, 10\}, \{4, 20\}, \{8, 17\}, \{16, 11\}, \{9, 22\}, \{18, 21\}, \{13, 19\}, \{3, 15\}, \{6, 7\}, \{12, 14\}\}

--- a/src/example.tex
+++ b/src/example.tex
@@ -1,29 +1,8 @@
-\def\exampletext{Example} % If English
-
-\NewDocumentEnvironment{example}{ O{} }
-{
-\colorlet{colexam}{red!55!black} % Global example color
-\newtcolorbox[use counter=example]{testexamplebox}{%
-    % Example Frame Start
-    empty,% Empty previously set parameters
-    title={\exampletext\ \thetcbcounter: #1},% use \thetcbcounter to access the testexample counter text
-    % Attaching a box requires an overlay
-    attach boxed title to top left,
-       % Ensures proper line breaking in longer titles
-       minipage boxed title,
-    % (boxed title style requires an overlay)
-    boxed title style={empty,size=minimal,toprule=0pt,top=4pt,left=3mm,overlay={}},
-    coltitle=colexam,fonttitle=\bfseries,
-    before=\par\medskip\noindent,parbox=false,boxsep=0pt,left=3mm,right=0mm,top=12pt,breakable,pad at break=0mm,
-       before upper=\csname @totalleftmargin\endcsname0pt, % Use instead of parbox=true. This ensures parskip is inherited by box.
-    % Handles box when it exists on one page only
-    overlay unbroken={\draw[colexam,line width=.5pt] ([xshift=-0pt]title.north west) -- ([xshift=-0pt]frame.south west); },
-    % Handles multipage box: first page
-    overlay first={\draw[colexam,line width=.5pt] ([xshift=-0pt]title.north west) -- ([xshift=-0pt]frame.south west); },
-    % Handles multipage box: middle page
-    overlay middle={\draw[colexam,line width=.5pt] ([xshift=-0pt]frame.north west) -- ([xshift=-0pt]frame.south west); },
-    % Handles multipage box: last page
-    overlay last={\draw[colexam,line width=.5pt] ([xshift=-0pt]frame.north west) -- ([xshift=-0pt]frame.south west); },%
-    }
-\begin{testexamplebox}}
-{\end{testexamplebox}\endlist}
+% https://tex.stackexchange.com/questions/231375/how-to-define-labels-within-a-tcolorbox
+\newtcolorbox[auto counter,number within=chapter]{example}[1][]{
+  enhanced,
+  breakable,
+  fonttitle=\scshape,
+  title={Example \thetcbcounter},
+  #1
+}


### PR DESCRIPTION
Using a different custom environment for Examples, based on `tcolorbox` and using the `label` argument fixes the problem. Also, the new Examples arguably look better than the old ones.