### PR TITLE
Fix theorem references in section 3.4

### DIFF
--- a/src/chapters/03_existence_proof.tex
+++ b/src/chapters/03_existence_proof.tex
@@ -561,9 +561,9 @@ We have already shown that $x^{2i} = x^{2j}$ is only true for $i = j$.
 So all the sums are unique, and the starter is strong.
 
 Hence, by Theorems
-\ref{XXX}
+\ref{thm:strong-starter}
 and
-\ref{XXX},
+\ref{thm:strong-starter-2},
 Room squares exist for all $p^n\equiv 3\pmod 4$, and in the case when $p^n\equiv 3\pmod 4$ is
 prime, these Room squares are based on $Z_p$.
 \end{proof}


### PR DESCRIPTION
These references were wrong in the original report but clearly the two previous theorems were meant to be referenced. So this change just adds those references.