### PR TITLE
Fix overflowing equations in Example 3.8

### DIFF
--- a/src/chapters/03_existence_proof.tex
+++ b/src/chapters/03_existence_proof.tex
@@ -1152,8 +1152,8 @@ Suppose we wished to triplicate the following Room square.
 
 \begin{equation}
   \begin{bmatrix}
-    \infty 0 &   - &     &  25 &   - &  16 &  34 \\
-    45 &  \infty 1 &     &   - &  36 &   - &  20 \\
+    \infty 0 &   - &  -  &  25 &   - &  16 &  34 \\
+    45 &  \infty 1 &  -  &   - &  36 &   - &  20 \\
     31 &  56 &  \infty 2 &   - &   - &  40 &   - \\
      - &  42 &  60 &  \infty 3 &   - &   - &  51 \\
     62 &   - &  53 &  01 &  \infty 4 &   - &   - \\
@@ -1163,24 +1163,24 @@ Suppose we wished to triplicate the following Room square.
   \label{eq:triple-room}
 \end{equation}
 
-Of course, assembling nine of these into an array is pointless, because the new square will have little in common with a $21 x 21$ Room square.
+Of course, assembling nine of these into an array is pointless, because the new square will have little in common with a $21 \times 21$ Room square.
 
 Suppose we just triplicate the first row.
 We have,
 
 \begin{equation*}
-  \begin{bmatrix}
+  \begin{bsmallmatrix}
     \infty 0 & - & - & 25 & - & 16 & 34 & \infty 0 & - & - & 25 & - & 16 & 34 & \infty 0 & - & - & 25 & - & 16 & 34 \\
-  \end{bmatrix}
+  \end{bsmallmatrix}
 \end{equation*}
 
 An obvious step to correct this is to triple the size of the set on which the square is based.
 Suppose we do that in the following way.
 
 \begin{equation*}
-  \begin{bmatrix}
+  \begin{bsmallmatrix}
     \infty_{1} 0_{1} & - & - & 2_{1}5_{1} & - & 1_{1}6_{2} & 3_{2}4_{1} & \infty_{2} 0_{2} & - & - & 2_{2}5_{2} & - & 1_{2}6_{2} & 3_{2}4_{2} & \infty_{3} 0_{3} & - & - & 2_{3}5_{3} & - & 1_{3}6_{3} & 3_{3}4_{3} \\
-  \end{bmatrix}
+  \end{bsmallmatrix}
 \end{equation*}
 
 Unfortunately, this row has simply too many elements.
@@ -1237,8 +1237,6 @@ The following arrangement of frames satisfies all the conditions we require, as 
 \end{equation}
 
 Now when we assemble the $R_{ij}$, something quite close to a Room square of side 21, based on $S$, is constructed.
-
-FIGURE 23 HERE
 
 \end{example}
 


### PR DESCRIPTION
Again we just used `bsmallmatrix` instead of `bmatrix`.