### PR TITLE
Fix overflowing enumerated environment in proof of Theorem 14

### DIFF
--- a/src/chapters/04_existence_theorem.tex
+++ b/src/chapters/04_existence_theorem.tex
@@ -7,14 +7,11 @@ There exists a Room square of side $v$, where $v$ is a positive integer differen
 
 \begin{proof}
 A Room square of side one exists trivially.
-
 Any positive integer can be rewritten in the form:
-
 \begin{equation}
 v = 3^{a}5^{b}n
 \end{equation}
-
-where $n$ is relatively prime to fifteen, i.e.  $(15, n) = 1$.
+where $n$ is relatively prime to fifteen, i.e. $(15, n) = 1$.
 
 Suppose that $a + b = 0$, then a Room square exists due to Theorems
 \ref{thm:starter-adder},
@@ -24,9 +21,7 @@ Suppose that $a + b = 0$, then a Room square exists due to Theorems
 \ref{thm:multiply},
 and
 \ref{thm:wallis}.
-
 For $a + b = 1$, then either $v = 3n$ or $v = 5n$.
-
 In both cases, provided $v > 5$, Theorem \ref{thm:wallis} guarantees the existence of a Room square of side $v$.
 
 Now consider $a + b = 2$.

--- a/wc.txt
+++ b/wc.txt
@@ -1,7 +1,7 @@
      252    2264   12892 src/chapters/01_introduction.tex
      449    2842   18753 src/chapters/02_graph_theoretic.tex
     1558   13690   78086 src/chapters/03_existence_proof.tex
-      87     869    4243 src/chapters/04_existence_theorem.tex
+      82     869    4237 src/chapters/04_existence_theorem.tex
     1910   13702   80828 src/chapters/05_balanced_room_squares.tex
-      48     337    2122 src/chapters/06_closing_remarks.tex
-    4304   33704  196924 total
+      30     337    2122 src/chapters/06_closing_remarks.tex
+    4281   33704  196918 total


### PR DESCRIPTION
On closer inspection this wasn't really a problem. It just appeared to be because there were so many indented paragraphs. Fixed by reducing number of paragraphs.