### PR TITLE
Fix typesetting of modulus operator

### DIFF
--- a/src/chapters/06_closing_remarks.tex
+++ b/src/chapters/06_closing_remarks.tex
@@ -18,7 +18,7 @@ By far the most significant remaining result which has not been included in the 
 His construction is based upon the theory of finite geometry, an area which has also contributed constructions for Room squares (the non-balanced kind).
 
 Other similar geometrical constructions have been used to establish the existence of $BRS(2^n)$, for $4 \leq n \leq 18$, $n$ even.
-The two smallest values of $n \equiv 0($mod 4) for which the existence of a $BRS(n)$ remains in doubt are 36 and 92.
+The two smallest values of $n \equiv 0 \pmod 4$ for which the existence of a $BRS(n)$ remains in doubt are 36 and 92.
 The first of these, along with many others, would be established by the doubling construction if a $SSBS$ could be found in $Z_{17}$.
 This remains one of the most significant open problems for $BRS$, namely to establish the existence of $SSBS$ in $Z_n$ when $n$ is a Fermat prime.
 

--- a/wc.txt
+++ b/wc.txt
@@ -3,5 +3,5 @@
     1558   13690   78086 src/chapters/03_existence_proof.tex
       82     869    4195 src/chapters/04_existence_theorem.tex
     1910   13702   80828 src/chapters/05_balanced_room_squares.tex
-      30     337    2122 src/chapters/06_closing_remarks.tex
-    4281   33704  196876 total
+      30     338    2123 src/chapters/06_closing_remarks.tex
+    4281   33705  196877 total


### PR DESCRIPTION
Just use LaTeX `\pmod` instead of switching back to text mode.