### PR TITLE
Highlight two inline definitions in the last section

### DIFF
--- a/src/chapters/06_closing_remarks.tex
+++ b/src/chapters/06_closing_remarks.tex
@@ -24,7 +24,8 @@ This remains one of the most significant open problems for $BRS$, namely to esta
 
 The link between graph theory and Room squares that was touched upon in the second chapter has opened many avenues of research.
 Possibly the most interesting of which is the existence of perfect Room squares.
-A one-factorisation of $K_n$ is said to be perfect if the union of two of its one-factors is a hamiltonian cycle of $K_n$.
-A perfect Room square is one of side $n$ in which both row and column factorisations of $K_{n + 1}$ are perfect.
+
+A one-factorisation of $K_n$ is said to be \inlinedef{perfect} if the union of two of its one-factors is a Hamiltonian cycle of $K_n$.
+A \inlinedef{perfect Room square} is one of side $n$ in which both row and column factorisations of $K_{n + 1}$ are perfect.
 Very little seems to be known about perfect one-factorisations.
 Individual examples of perfect Room squares of side 11 have been constructed but no infinite classes have yet been found.

--- a/wc.txt
+++ b/wc.txt
@@ -3,5 +3,5 @@
     1558   13690   78086 src/chapters/03_existence_proof.tex
       82     869    4195 src/chapters/04_existence_theorem.tex
     1910   13702   80828 src/chapters/05_balanced_room_squares.tex
-      30     338    2123 src/chapters/06_closing_remarks.tex
-    4281   33705  196877 total
+      31     338    2148 src/chapters/06_closing_remarks.tex
+    4282   33705  196902 total


### PR DESCRIPTION
For some reason the definitions of perfect one-factorisation and perfect Room square were not highlighted as such. Now they have been.