### PR TITLE
Add missing author names in Chapter 6

### DIFF
--- a/src/chapters/06_closing_remarks.tex
+++ b/src/chapters/06_closing_remarks.tex
@@ -2,19 +2,21 @@
 \label{ch:closing-remarks}
 
 The results we have established in the previous chapter regarding the existence of balanced Room squares represent by no means the complete story.
-\cite{duExistenceSymmetricSkew1988} have established the existence of $SSBS$ for all prime powers
+Du and Hwang
+\cite{duExistenceSymmetricSkew1988}
+have established the existence of $SSBS$ for all prime powers
 \begin{equation}
 q = 2^{\alpha}t + 1, \alpha \geq 2, t \geq 3
 \end{equation}
 where $t$ odd.
 
-Further, the construction due originally to
+Further, Anderson has shown that consequently the construction due originally to Hwang, Kang and Yu
 \cite{hwangCompleteBalancedHowell1984}
-but corrected by
+but corrected in
 \cite{andersonConstructionBalancedRoom1999}
 allows us to state the existence of the corresponding $BRS(2q + 2)$ in one particular case.
 
-By far the most significant remaining result which has not been included in the previous chapter is due to B.A. Anderson who proved that $BRS(2^n)$ exist for all odd $n \geq 3$.
+By far the most significant remaining result which has not been included in the previous chapter is due to B. A. Anderson who proved that $BRS(2^n)$ exist for all odd $n \geq 3$.
 His construction is based upon the theory of finite geometry, an area which has also contributed constructions for Room squares (the non-balanced kind).
 
 Other similar geometrical constructions have been used to establish the existence of $BRS(2^n)$, for $4 \leq n \leq 18$, $n$ even.

--- a/wc.txt
+++ b/wc.txt
@@ -3,5 +3,5 @@
     1558   13690   78086 src/chapters/03_existence_proof.tex
       82     869    4195 src/chapters/04_existence_theorem.tex
     1910   13702   80828 src/chapters/05_balanced_room_squares.tex
-      31     338    2148 src/chapters/06_closing_remarks.tex
-    4282   33705  196902 total
+      33     351    2218 src/chapters/06_closing_remarks.tex
+    4284   33718  196972 total


### PR DESCRIPTION
When referencing a few works the names of the authors were missing from the main text. These have been added.