### PR TITLE
Rewrite text to avoid reference to missing Figure 41

### DIFF
--- a/src/chapters/05_balanced_room_squares.tex
+++ b/src/chapters/05_balanced_room_squares.tex
@@ -1164,11 +1164,10 @@ Now, assemble the large array and apply the construction using the following tra
   T_1 &= \{((0 + g)_2, (5 + g)_2)\, |\, g \in Z_{13}\} \\
   T_2 &= \{((0 + g)_2, (11 + g)_2)\, |\, g \in Z_{13}\}
 \end{align}
-The obtained array is the $\BRS(28)$ in XXX.
 
-*** MISSING FIGURE HERE ***
+The obtained array is a $\BRS(28)$.
 
-The finished array XXX is an $ORS$ because it contains one ordered pair corresponding to each unordered pair from the set
+The finished array is an $ORS$ because it contains one ordered pair corresponding to each unordered pair from the set
 \begin{equation}
 \{\infty _1, \infty _2, 0_1, \ldots, p - 1_1, 0_2, \ldots, p - 1_2\}
 \end{equation}

--- a/wc.txt
+++ b/wc.txt
@@ -2,6 +2,6 @@
      449    2842   18753 src/chapters/02_graph_theoretic.tex
     1558   13690   78086 src/chapters/03_existence_proof.tex
       82     869    4195 src/chapters/04_existence_theorem.tex
-    1469   13701   81038 src/chapters/05_balanced_room_squares.tex
+    1468   13693   80997 src/chapters/05_balanced_room_squares.tex
       33     351    2218 src/chapters/06_closing_remarks.tex
-    3843   33717  197182 total
+    3842   33709  197141 total


### PR DESCRIPTION
With the next version, which might have TikZ drawings instead of LaTeX equations we will re-instate Figure 41 (from the original manuscript).