### PR TITLE
Move operator definitions to macros.tex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,4 +37,4 @@ hooks:
 	.git/hooks/post-commit  \;
 
 count:
-	wc src/main.tex > count.txt 
+	wc src/chapters/*.tex > wc.txt 

--- a/src/macros.tex
+++ b/src/macros.tex
@@ -4,3 +4,7 @@
 \newtheorem{lemma}[theorem]{Lemma}
 \newtheorem{corollary}{Corollary}[theorem]
 
+\DeclareMathOperator{\BIBD}{BIBD}
+\DeclareMathOperator{\BRS}{BRS}
+\DeclareMathOperator{\CBHR}{CBHR}
+\DeclareMathOperator{\SSBS}{SSBS}

--- a/src/room-draft.tex
+++ b/src/room-draft.tex
@@ -46,11 +46,6 @@
 \input{example}
 \input{macros}
 
-\DeclareMathOperator{\BIBD}{BIBD}
-\DeclareMathOperator{\BRS}{BRS}
-\DeclareMathOperator{\CBHR}{CBHR}
-\DeclareMathOperator{\SSBS}{SSBS}
-
 \title{Room Squares}
 \author{Matthew Henderson}
 \date{\today}

--- a/src/room.tex
+++ b/src/room.tex
@@ -46,11 +46,6 @@
 \input{example}
 \input{macros}
 
-\DeclareMathOperator{\BIBD}{BIBD}
-\DeclareMathOperator{\BRS}{BRS}
-\DeclareMathOperator{\CBHR}{CBHR}
-\DeclareMathOperator{\SSBS}{SSBS}
-
 \title{Room Squares}
 \author{Matthew Henderson}
 \date{\today}


### PR DESCRIPTION
There's no reason for them to be anywhere else, afaik.