### PR TITLE
Fix indexing issue

### DIFF
--- a/src/macros.tex
+++ b/src/macros.tex
@@ -1,4 +1,5 @@
-\newcommand{\inlinedef}[1]{\emph{\index{#1}}}
+\newcommand{\inlinedef}[1]{\emph{#1}\index{#1}}
+\newcommand{\inlinedefnoidx}[1]{\emph{#1}}
 
 \newtheorem{theorem}{Theorem}
 \newtheorem{lemma}[theorem]{Lemma}

--- a/src/main/bibd-and-brs.tex
+++ b/src/main/bibd-and-brs.tex
@@ -1,5 +1,5 @@
 In any Room square, the pairs $\{x, y\}$ are unordered.
-If we replace these pairs by one of the ordered pairs $(x, y)$ or $(y, x)$ we call the resulting array an \inlinedef{ordered Room square} (ORS).
+If we replace these pairs by one of the ordered pairs $(x, y)$ or $(y, x)$ we call the resulting array an \inlinedefnoidx{ordered Room square}\index{Room square!ordered} (ORS).
 
 Consider the following ordered Room square:
 \begin{equation}

--- a/src/main/kirkmans-problem.tex
+++ b/src/main/kirkmans-problem.tex
@@ -45,4 +45,4 @@ Thereby solving the problem.
   \caption{Kirkman's Schoolgirl's Solution}
 \end{table}
 
-Kirkman was a notable mathematician who is often regarded as the originator of the object in \eqref{eq:roomsquare}, which has subsequently become known as a Room square (after T.G. Room).
+Kirkman was a notable mathematician who is often regarded as the originator of the object in \eqref{eq:roomsquare}, which has subsequently become known as a \inlinedef{Room square} (after T.G. Room).

--- a/wc.txt
+++ b/wc.txt
@@ -1,4 +1,4 @@
-      57     368    2593 src/main/bibd-and-brs.tex
+      57     369    2625 src/main/bibd-and-brs.tex
       31     265    1636 src/main/bibd.tex
      277    2223   13431 src/main/brs-cbhr-starter-adder.tex
      262    2123   13221 src/main/brs-multiplication.tex
@@ -15,7 +15,7 @@
      204    1119    7403 src/main/hill-climbing-room.tex
        5      81     572 src/main/hill-climbing.tex
      127     818    5311 src/main/hill-one-factorisation.tex
-      48     433    2367 src/main/kirkmans-problem.tex
+      48     433    2379 src/main/kirkmans-problem.tex
      273    1997   10924 src/main/mullin-nemeth.tex
      100    1029    5721 src/main/multiplication-theorem.tex
      413    3799   22133 src/main/n-tuplication.tex
@@ -26,4 +26,4 @@
      500    4365   25146 src/main/symmetric-skew-balanced-starters.tex
       90     937    5180 src/main/tg-room.tex
       54     527    3068 src/main/tournaments.tex
-    3480   29953  175451 total
+    3480   29954  175495 total


### PR DESCRIPTION
I misunderstood how to use the index macro. Fixed inlinedef and added inlinedefnoidx to support special cases. An example is nesting the definition of balanced Room square under the entry for Room square.